### PR TITLE
Update code analysis tools (Don't merge yet)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+# dependencies
+install: "pip install -r requirements.txt"
+# command to run tests
+# script: pytest

--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ of those, model fitting can be run again.
 
     lrcr_fit.plot_fit_ts()
 
-.. |Build status| image:: https://ci.appveyor.com/api/projects/status/2cbutmj6i890uujj?svg=true
-   :target: https://ci.appveyor.com/project/abrahamnunes/fitr
+.. |Build status| image:: 
+   :target: https://travis-ci.org/ComputationalPsychiatry/fitr
 .. |Documentation Status| image:: https://readthedocs.com/projects/computationalpsychiatry-fitr/badge/?version=latest
    :target: https://computationalpsychiatry-fitr.readthedocs-hosted.com/en/latest/?badge=latest


### PR DESCRIPTION
Updated readme to use travis instead of appveyor and added travis file.

I figured we can just remove the appveyor references for now since we are not focusing on windows yet, but if possible could you add permission to circleci to access the project @abrahamnunes ? It does not seem to have permission, and might be handy in tracking tests we write.