### PR TITLE
Fixed perseveration parameter code name

### DIFF
--- a/fitr/generative_models.py
+++ b/fitr/generative_models.py
@@ -244,7 +244,7 @@ class twostep(GenerativeModel):
                           'Choice Randomness',
                           'Model-Based Weight',
                           'Perseveration'],
-                'code' : ['lr', 'cr', 'w', 'p']
+                'code' : ['lr', 'cr', 'w', 'persev']
             }
             self.model = """
                 data {
@@ -353,7 +353,7 @@ class twostep(GenerativeModel):
                           'Eligibility Trace',
                           'Model-Based Weight',
                           'Perseveration'],
-                'code' : ['lr', 'cr', 'et', 'w', 'p']
+                'code' : ['lr', 'cr', 'et', 'w', 'persev']
             }
             self.model = """
                 data {


### PR DESCRIPTION
The code name for perseveration parameter was incorrect, which threw an error when fitting two-step task data. I fixed this.